### PR TITLE
feat: add travis ci config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: python
+python:
+  - "3.4"
+  - "3.5"
+  - "3.6"
+# command to install dependencies
+install:
+  - pip install flake8 pytest
+# command to run tests
+script:
+  - python3 -m pytest
+  - python3 -m flake8


### PR DESCRIPTION
Add initial Travis-CI configuration, testing different Python versions.
It runs flake8 code style checks and pytests.