### PR TITLE
docs: adapt readme and add guidelines

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,68 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project maintainer at <s@mlng.net>. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,16 @@
+## Contributing to PyCayenneLPP
+
+As a free open source software project (FOSS), PyCayenneLPP welcomes
+contributions of many forms. Essentially it comes down to either open
+an Issue or Pull Request on Github. Issues are used (but not limited)
+to report bugs, make feature requests, or ask questions. In the same
+way Pull Request are used (but not limited) to provide patches, make
+improvements to documentation, or add tests.
+
+To ensure and maintain code quality and robustness pull requests must
+pass Travis CI before being merged into master.
+
+## Code of conduct
+
+Please note that this project is released with a Contributor Code of Conduct.
+By participating in this project you agree to abide by its terms.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# PyCayenneLPP
+
+A Cayenne Low Power Payload (CayenneLPP) decoder and encoder for Python.
+This is a free open source software project published under the permissive
+[MIT License](LICENSE).
+
+Please take note of the [contributing guidelines](CONTRIBUTING.md) and the
+[Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Requirements
+
+PyCayenneLPP does not have any external dependencies and only uses builtin
+functions and types of Python 3. It requires at least Python in version 3.4.
+The PyCayenneLPP package is available via PyPi using `pip`. To install it run:
+
+```
+pip3 install pycayennelpp
+```
+
+## Usage
+
+Simply add this import to your application to utilise PyCayenneLPP:
+
+```
+import cayennelpp
+```

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,0 @@
-PyCayenneLPP
-============
-
-A Cayenne Low Power Payload (CayenneLPP) decoder and encoder for Python.
-
-Usage
------

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 
 def readme():
-    with open('README.rst') as f:
+    with open('README.md') as f:
         return f.read()
 
 


### PR DESCRIPTION
Besides extending the README, this adds basic contributing guidelines
and an initial code of conduct.