### PR TITLE
feat: add MicroPython support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,27 @@ fly as soon as a certain number of new features and fixes have been made.
 PyCayenneLPP does not have any external dependencies, but only uses builtin
 functions and types of Python 3. At least Python in version 3.4 is required.
 
-### Prerequisites
+### Python 3 Prerequisites
 
 The PyCayenneLPP package is available via PyPi using `pip`. To install it run:
 
 ```Shell
 pip3 install pycayennelpp
+```
+
+### MicroPython Prerequisites
+
+MicroPython does not include the libraries `base64` and `logging` per default.
+While the latter rather optional for embedded devices, the former is essential.
+It can be installed from the
+[micropython-lib](https://github.com/micropython/micropython-lib/tree/master/base64)
+project via tools like [ampy](https://github.com/adafruit/ampy).
+
+```Shell
+git clone https://github.com/micropython/micropython-lib.git
+cd micropython-lib/
+pip install ampy
+ampy -p /dev/ttyACM0 put base64/ # port may be different
 ```
 
 ### Usage Examples

--- a/cayennelpp/lpp_data.py
+++ b/cayennelpp/lpp_data.py
@@ -1,6 +1,11 @@
 from .lpp_type import get_lpp_type
 
-import logging
+try:
+    import logging
+except ImportError:
+    class logging:
+        def debug(self, *args, **kwargs):
+            pass
 
 
 class LppData(object):

--- a/cayennelpp/lpp_frame.py
+++ b/cayennelpp/lpp_frame.py
@@ -1,7 +1,12 @@
 from .lpp_data import LppData
 
 import base64
-import logging
+try:
+    import logging
+except ImportError:
+    class logging:
+        def debug(self, *args, **kwargs):
+            pass
 
 
 class LppFrame(object):

--- a/cayennelpp/lpp_type.py
+++ b/cayennelpp/lpp_type.py
@@ -1,4 +1,9 @@
-import logging
+try:
+    import logging
+except ImportError:
+    class logging:
+        def debug(self, *args, **kwargs):
+            pass
 
 
 def lpp_digital_io_from_bytes(buf):
@@ -520,4 +525,10 @@ def get_lpp_type(tid):
     """Returns the LppType instance for a given `tid` or `None` if not found"""
     if not isinstance(tid, int):
         raise AssertionError()
-    return next(filter(lambda x: x.tid == tid, LPP_TYPES), None)
+    # `next` on MicroPython does not support `default` parameter
+    # use try/except construct instead
+    # https://docs.micropython.org/en/latest/genrst/modules.html#second-argument-to-next-is-not-implemented
+    try:
+        return next(filter(lambda x: x.tid == tid, LPP_TYPES))
+    except StopIteration:
+        return None


### PR DESCRIPTION
this feature/fix allows to run the library on MicroPython, which is
usefull when using embedded devices.

The MicroPython library does not support the `debug` call fully,
therefore it is removed by a pseudo function not printing anything. This
seems reasonable as most embedded devices are not constantly connected
to a serial port.

The MicroPython function `filter` does not support the `default` param,
therefore it catches the `StopIteration` and then returns `None`.

Also added a description in the `README.md` on the installation of the
missing `base64` library.

Signed-off-by: Paul Spooren <mail@aparcar.org>