### PR TITLE
fix: fix pytest-cov to version < 2.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
   - "3.6"
 # command to install dependencies
 install:
-  - pip install flake8 pytest coverage pytest-cov codacy-coverage
+  - pip install flake8 pytest coverage "pytest-cov<2.6.0" codacy-coverage
 # command to run tests
 script:
   - python3 -m flake8


### PR DESCRIPTION
workaround to fix Travis build errors due to Python dependency mismatches