### PR TITLE
fixup: fix add_gps lpp number

### DIFF
--- a/cayennelpp/lpp_frame.py
+++ b/cayennelpp/lpp_frame.py
@@ -121,5 +121,5 @@ class LppFrame(object):
 
     def add_gps(self, channel, lat, lon, alt):
         """Create and add a GPS LppData"""
-        gps = LppData(channel, 134, (lat, lon, alt, ))
+        gps = LppData(channel, 136, (lat, lon, alt, ))
         self.data.append(gps)


### PR DESCRIPTION
lpp was 134 and therefore interpret as gyro

Signed-off-by: Paul Spooren <mail@aparcar.org>