### PR TITLE
feat: Support Unix Time

### DIFF
--- a/cayennelpp/lpp_frame.py
+++ b/cayennelpp/lpp_frame.py
@@ -105,6 +105,11 @@ class LppFrame(object):
         hum = LppData(channel, 104, (value, ))
         self.data.append(hum)
 
+    def add_unix_time(self, channel, value):
+        """Create and add a unix time sensor LppData"""
+        hum = LppData(channel, 133, (value, ))
+        self.data.append(hum)
+
     def add_accelerometer(self, channel, x, y, z):
         """Create and add a accelerometer sensor LppData"""
         acc = LppData(channel, 113, (x, y, z, ))

--- a/cayennelpp/tests/test_lpp_data.py
+++ b/cayennelpp/tests/test_lpp_data.py
@@ -1,4 +1,6 @@
 import pytest
+from datetime import datetime
+from datetime import timezone as tz
 
 from cayennelpp.lpp_data import LppData
 
@@ -24,6 +26,14 @@ def test_gps_from_bytes():
                          0x00, 0x03, 0xe8])
     gps_dat = LppData.from_bytes(gps_buf)
     assert gps_buf == gps_dat.bytes()
+
+
+def test_unix_time_from_bytes():
+    # 1970-01-01T08:00Z (ie unix time 0)
+    buff = bytearray([0x01, 0x85, 0x00, 0x00, 0x00, 0x00])
+    data = LppData.from_bytes(buff)
+    assert buff == data.bytes()
+    assert data.value == (datetime.fromtimestamp(0, tz.utc),)
 
 
 def test_init_invalid_type():

--- a/cayennelpp/tests/test_lpp_frame.py
+++ b/cayennelpp/tests/test_lpp_frame.py
@@ -1,4 +1,6 @@
 import pytest
+from datetime import datetime
+from datetime import timezone as tz
 
 from cayennelpp.lpp_frame import LppFrame
 
@@ -62,6 +64,15 @@ def test_add_sensors(frame):
     frame.add_gyrometer(7, 1.234, -1.234, 0.0)
     frame.add_gps(8, 1.234, -1.234, 0.0)
     assert len(frame.data) == 7
+
+
+def test_add_unix_time(frame):
+    frame.add_unix_time(0, datetime.now(tz.utc))
+    frame.add_unix_time(1, datetime.fromtimestamp(0))
+    assert len(frame.data) == 2
+    assert frame.data[0].type == 133
+    assert frame.data[1].type == 133
+    frame.bytes()
 
 
 def test_add_temperature(frame):

--- a/cayennelpp/tests/test_lpp_type.py
+++ b/cayennelpp/tests/test_lpp_type.py
@@ -1,4 +1,7 @@
 import pytest
+from cayennelpp.utils import datetime_as_utc
+from datetime import datetime, timedelta
+from datetime import timezone as tz
 
 from cayennelpp.lpp_type import (lpp_digital_io_to_bytes,
                                  lpp_digital_io_from_bytes,
@@ -20,6 +23,8 @@ from cayennelpp.lpp_type import (lpp_digital_io_to_bytes,
                                  lpp_gyro_from_bytes,
                                  lpp_gps_to_bytes,
                                  lpp_gps_from_bytes,
+                                 lpp_unix_time_to_bytes,
+                                 lpp_unix_time_from_bytes,
                                  get_lpp_type,
                                  LppType)
 
@@ -96,6 +101,49 @@ def test_illuminance_invalid_val():
 def test_illuminance_negative_val():
     with pytest.raises(Exception):
         lpp_illuminance_to_bytes((-1,))
+
+
+def test_unix_time_datetime_without_tz():
+    now = datetime.now()
+    utcnow = datetime_as_utc(now.replace(microsecond=0))
+    vol_buf = lpp_unix_time_to_bytes((now,))
+    assert lpp_unix_time_from_bytes(vol_buf) == (utcnow,)
+
+
+def test_unix_time_datetime_with_tz():
+    now = datetime.now(tz=tz(timedelta(hours=-5)))
+    utcnow = datetime_as_utc(now.replace(microsecond=0))
+    vol_buf = lpp_unix_time_to_bytes((now,))
+    assert lpp_unix_time_from_bytes(vol_buf) == (utcnow,)
+
+
+def test_unix_time_int():
+    val = datetime.fromtimestamp(5, tz.utc)
+    vol_buf = lpp_unix_time_to_bytes((5,))
+    assert lpp_unix_time_from_bytes(vol_buf) == (val,)
+
+
+def test_unix_time_invalid_buf():
+    with pytest.raises(Exception):
+        lpp_unix_time_from_bytes(bytearray([0x00]))
+
+
+def test_unix_time_invalid_val():
+    with pytest.raises(Exception):
+        lpp_unix_time_to_bytes((0, 1))
+    val = datetime.fromtimestamp(-5, tz.utc)
+    with pytest.raises(ValueError):
+        # negative value
+        lpp_unix_time_to_bytes((val,))
+
+
+def test_unix_time_negative_val():
+    with pytest.raises(Exception):
+        lpp_unix_time_to_bytes((-1,))
+    with pytest.raises(Exception):
+        # -4 years (-4*365*24*3600 seconds)
+        buff = bytearray([0xf8, 0x7b, 0x32, 0x0])
+        lpp_unix_time_from_bytes(buff)
 
 
 def test_presence():

--- a/cayennelpp/tests/test_utils.py
+++ b/cayennelpp/tests/test_utils.py
@@ -1,0 +1,11 @@
+from datetime import datetime, timedelta
+from datetime import timezone as tz
+
+from cayennelpp.utils import datetime_as_utc
+
+
+def test_datetime_as_utc():
+    """Test converting naive datetime to utc datetime."""
+    now = datetime.now().replace(microsecond=0, second=0)
+    utcnow = datetime.now(tz.utc).replace(microsecond=0, second=0)
+    assert datetime_as_utc(now) - utcnow <= timedelta(seconds=2)

--- a/cayennelpp/utils.py
+++ b/cayennelpp/utils.py
@@ -1,0 +1,19 @@
+from datetime import datetime
+from datetime import timezone as tz
+
+
+def datetime_as_utc(dt):
+    """Helper function necessary for pyton <=3.5
+    to convert naive datetime to utc"""
+    try:
+        # works with naive datetime object in python 3.6+
+        return dt.astimezone(tz.utc)
+    except ValueError:
+        # necessary in python <= 3.5
+        pass
+    if dt.tzinfo is None:
+        now = datetime.now().replace(microsecond=0, second=0)
+        utcnow = datetime.utcnow().replace(microsecond=0, second=0)
+        localtz = tz(now - utcnow)
+        dt = datetime.fromtimestamp(dt.timestamp(), localtz)
+    return dt.astimezone(tz.utc)


### PR DESCRIPTION
fix: Support Unix Time as unsigned 4 byte unix timestamp as specified in https://github.com/ElectronicCats/CayenneLPP/blob/master/decoders/decoder.js 

It converts and restores datetime objects. It also supports directly providing an integer/float timestamp.

For naive datetime objects (without timezone) it assumes the timezone is the system timezone. It converts to utc before converting, and returns back as a datetime object with timezone=utc. For timestamp integers, it is assumed this already is the timestamp in utc timezone (ie no conversion is done).

No other datetime libraries are required beyond the builtin datetime module.