### PR TITLE
feat: Add support for generic 4 byte unsigned integer

### DIFF
--- a/cayennelpp/lpp_frame.py
+++ b/cayennelpp/lpp_frame.py
@@ -85,6 +85,11 @@ class LppFrame(object):
         aout = LppData(channel, 3, (value, ))
         self.data.append(aout)
 
+    def add_generic(self, channel, value):
+        """Create and add a generic 4-byte unsigned integer LppData"""
+        din = LppData(channel, 100, (value, ))
+        self.data.append(din)
+
     def add_luminosity(self, channel, value):
         """Create and add an illuminance sensor LppData"""
         lux = LppData(channel, 101, (value, ))

--- a/cayennelpp/lpp_type.py
+++ b/cayennelpp/lpp_type.py
@@ -81,6 +81,46 @@ def lpp_analog_io_to_bytes(data):
     return buf
 
 
+def lpp_generic_from_bytes(buf):
+    """
+    Convert a 4 byte unsigned integer from bytes.
+    """
+    logging.debug("lpp_generic_from_bytes")
+    logging.debug("  in:    bytes = %s, length = %d", buf, len(buf))
+    if not len(buf) == 4:
+        raise AssertionError()
+    val_i = ((buf[0] << 24) | (buf[1] << 16) | (buf[2] << 8) | buf[3])
+    logging.debug("  out:   value = %d", val_i)
+    return (val_i,)
+
+
+def lpp_generic_to_bytes(data):
+    """
+    Convert an unsigned 4 byte integer to byte array.
+    """
+    logging.debug("lpp_generic_time_to_bytes")
+    if not isinstance(data, tuple):
+        data = (data,)
+    if not len(data) == 1:
+        raise ValueError("Only one value allowed.")
+    buf = bytearray([0x00, 0x00, 0x00, 0x00])
+    val = data[0]
+    logging.debug("  in:    value = %s", val)
+    val_i = int(val)
+    logging.debug("  in:    value = %i", val_i)
+    if val_i < 0:
+        raise ValueError("Negative values are not allowed")
+    if val_i > 4294967295:
+        raise ValueError("Values larger than 4294967295 are not allowed")
+    logging.debug("  in:    value = %d", val_i)
+    buf[0] = (val_i >> 24) & 0xff
+    buf[1] = (val_i >> 16) & 0xff
+    buf[2] = (val_i >> 8) & 0xff
+    buf[3] = (val_i) & 0xff
+    logging.debug("  out:   bytes = %s, length = %d", buf, len(buf))
+    return buf
+
+
 def lpp_illuminance_from_bytes(buf):
     """
     Decode illuminance sensor data from CyaenneLPP byte buffer,
@@ -502,6 +542,8 @@ LPP_TYPES = [
             lpp_analog_io_from_bytes, lpp_analog_io_to_bytes),
     LppType(3, 'Analog Output', 2, 1,
             lpp_analog_io_from_bytes, lpp_analog_io_to_bytes),
+    LppType(100, 'Generic', 4, 1,
+            lpp_generic_from_bytes, lpp_generic_to_bytes),
     LppType(101, 'Illuminance Sensor', 2, 1,
             lpp_illuminance_from_bytes, lpp_illuminance_to_bytes),
     LppType(102, 'Presence Sensor', 1, 1,

--- a/cayennelpp/tests/test_lpp_data.py
+++ b/cayennelpp/tests/test_lpp_data.py
@@ -17,6 +17,20 @@ def test_accelerometer_from_bytes():
     assert acc_buf == acc_dat.bytes()
 
 
+def test_generic_from_bytes():
+    buff = bytearray([0x00, 0x64, 0xff, 0xff, 0xff, 0xfb])
+    data = LppData.from_bytes(buff)
+    assert buff == data.bytes()
+    assert data.type == 100
+    assert data.value == (4294967291,)
+
+
+def test_generic_from_bytes_invalid_size():
+    with pytest.raises(Exception):
+        buf = bytearray([0x00, 0x64, 0x00, 0x00, 0x00])
+        LppData.from_bytes(buf)
+
+
 def test_gps_from_bytes():
     # 01 88 06 76 5f f2 96 0a 00 03 e8
     gps_buf = bytearray([0x01, 0x88, 0x06, 0x76,

--- a/cayennelpp/tests/test_lpp_frame.py
+++ b/cayennelpp/tests/test_lpp_frame.py
@@ -64,6 +64,12 @@ def test_add_sensors(frame):
     assert len(frame.data) == 7
 
 
+def test_add_generic(frame):
+    frame.add_generic(0, 4294967295)
+    frame.add_generic(1, 1)
+    assert len(frame.data) == 2
+
+
 def test_add_temperature(frame):
     frame.add_temperature(2, 12.3)
     frame.add_temperature(3, -32.1)

--- a/cayennelpp/tests/test_lpp_type.py
+++ b/cayennelpp/tests/test_lpp_type.py
@@ -20,6 +20,8 @@ from cayennelpp.lpp_type import (lpp_digital_io_to_bytes,
                                  lpp_gyro_from_bytes,
                                  lpp_gps_to_bytes,
                                  lpp_gps_from_bytes,
+                                 lpp_generic_to_bytes,
+                                 lpp_generic_from_bytes,
                                  get_lpp_type,
                                  LppType)
 
@@ -96,6 +98,31 @@ def test_illuminance_invalid_val():
 def test_illuminance_negative_val():
     with pytest.raises(Exception):
         lpp_illuminance_to_bytes((-1,))
+
+
+def test_generic():
+    val = 4294967295
+    vol_buf = lpp_generic_to_bytes((val,))
+    assert lpp_generic_from_bytes(vol_buf) == (val,)
+
+
+def test_generic_invalid_buf():
+    with pytest.raises(Exception):
+        lpp_generic_from_bytes(bytearray([0x00, 0x00, 0x00]))
+
+
+def test_generic_invalid_val():
+    with pytest.raises(Exception):
+        lpp_generic_to_bytes((0, 1))
+    with pytest.raises(ValueError):
+        # val exceeds 4 bytes
+        val = 4294967297
+        lpp_generic_to_bytes((val,))
+
+
+def test_generic_negative_val():
+    with pytest.raises(Exception):
+        lpp_generic_to_bytes((-1,))
 
 
 def test_presence():


### PR DESCRIPTION
According to specs in https://github.com/ElectronicCats/CayenneLPP/blob/master/decoders/decoder.js added a "generic" unsigned 4-byte integer. This should be good for many applications.