### PR TITLE
feat: add __len__ function to LppFrame

### DIFF
--- a/cayennelpp/lpp_frame.py
+++ b/cayennelpp/lpp_frame.py
@@ -34,6 +34,10 @@ class LppFrame(object):
         out = out + "])"
         return out
 
+    def __len__(self):
+        """Return number of data elements in a LppFrame"""
+        return len(self.data)
+
     @classmethod
     def from_bytes(cls, buf):
         """Parse LppFrame from a given byte string"""

--- a/cayennelpp/tests/test_lpp_frame.py
+++ b/cayennelpp/tests/test_lpp_frame.py
@@ -30,19 +30,19 @@ def test_frame_from_bytes():
     buf = bytearray([0x03, 0x67, 0x01, 0x10, 0x05, 0x67, 0x00, 0xff])
     frame = LppFrame.from_bytes(buf)
     assert buf == frame.bytes()
-    assert len(frame.data) == 2
+    assert len(frame) == 2
 
 
 def test_frame_from_base64():
     base64 = "AYgILMMBiIMAAAACAAY="
     frame = LppFrame.from_base64(base64)
-    assert len(frame.data) == 2
+    assert len(frame) == 2
 
 
 def test_add_digital_io(frame):
     frame.add_digital_input(0, 21)
     frame.add_digital_output(1, 42)
-    assert len(frame.data) == 2
+    assert len(frame) == 2
 
 
 def test_add_analog_io(frame):
@@ -50,7 +50,7 @@ def test_add_analog_io(frame):
     frame.add_analog_input(1, -12.34)
     frame.add_analog_output(0, 56.78)
     frame.add_analog_output(1, -56.78)
-    assert len(frame.data) == 4
+    assert len(frame) == 4
 
 
 def test_add_sensors(frame):
@@ -61,13 +61,13 @@ def test_add_sensors(frame):
     frame.add_barometer(6, 999.0)
     frame.add_gyrometer(7, 1.234, -1.234, 0.0)
     frame.add_gps(8, 1.234, -1.234, 0.0)
-    assert len(frame.data) == 7
+    assert len(frame) == 7
 
 
 def test_add_voltage(frame):
     frame.add_voltage(0, 25.2)
     frame.add_voltage(1, 120.2)
-    assert len(frame.data) == 2
+    assert len(frame) == 2
     assert frame.data[0].type == 116
     assert frame.data[1].type == 116
     frame.add_voltage(2, -25)
@@ -83,20 +83,20 @@ def test_add_load(frame):
 def test_add_generic(frame):
     frame.add_generic(0, 4294967295)
     frame.add_generic(1, 1)
-    assert len(frame.data) == 2
+    assert len(frame) == 2
 
 
 def test_add_temperature(frame):
     frame.add_temperature(2, 12.3)
     frame.add_temperature(3, -32.1)
-    assert len(frame.data) == 2
+    assert len(frame) == 2
 
 
 def test_add_humidity(frame):
     frame.add_humidity(2, 12.3)
     frame.add_humidity(3, 45.6)
     frame.add_humidity(4, 78.9)
-    assert len(frame.data) == 3
+    assert len(frame) == 3
 
 
 def test_lpp_frame_str_empty(frame):


### PR DESCRIPTION
this adds `__len__` to LppFrame to simplify usage of `len` on LppFrame, i.e., now its possible to write `len(frame)` instead of `len(frame.data)`.