### PR TITLE
feat: add __iter__ to LppFrame

### DIFF
--- a/cayennelpp/lpp_frame.py
+++ b/cayennelpp/lpp_frame.py
@@ -38,6 +38,13 @@ class LppFrame(object):
         """Return number of data elements in a LppFrame"""
         return len(self.data)
 
+    def __iter__(self):
+        """Return an iterator over all data elements in a LppFrame"""
+        count = 0
+        while count < len(self.data):
+            yield self.data[count]
+            count += 1
+
     @classmethod
     def from_bytes(cls, buf):
         """Parse LppFrame from a given byte string"""

--- a/cayennelpp/tests/test_lpp_frame.py
+++ b/cayennelpp/tests/test_lpp_frame.py
@@ -118,3 +118,14 @@ def test_lpp_frame_str_data(frame):
     frame.add_temperature(2, 12.3)
     frame.add_temperature(3, -32.1)
     print(frame)
+
+
+def test_lpp_frame_iterator(frame):
+    frame.add_temperature(2, 12.3)
+    frame.add_humidity(3, 45.6)
+    frame.add_load(1, 160.987)
+    counter = 0
+    for val in frame:
+        print(val)
+        counter += 1
+    assert counter == 3


### PR DESCRIPTION
Add iterator functionality to LppFrame to allow for easier access
to LppData objects in a LppFrame. Code example

```
frame = LppFrame()
frame.add_humidity(0, 33.3)
frame.add_temperature(0, -10.5)
frame.add_temperature(1, 26.1)
for val in frame:
    print(val)
```