### PR TITLE
Register three new type, standardize sign validtion, parameterise test.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,4 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+helper.py

--- a/cayennelpp/lpp_frame.py
+++ b/cayennelpp/lpp_frame.py
@@ -163,3 +163,18 @@ class LppFrame(object):
         """Create and add a load LppData"""
         load = LppData(channel, 122, (value, ))
         self.data.append(load)
+
+    def add_direction(self, channel, value):
+        """Create and add a load LppData"""
+        direction = LppData(channel, 132, (value, ))
+        self.data.append(direction)
+
+    def add_current(self, channel, value):
+        """Create and add a load LppData"""
+        current = LppData(channel, 117, (value, ))
+        self.data.append(current)
+
+    def add_power(self, channel, value):
+        """Create and add a load LppData"""
+        power = LppData(channel, 128, (value, ))
+        self.data.append(power)

--- a/cayennelpp/lpp_type.py
+++ b/cayennelpp/lpp_type.py
@@ -98,10 +98,10 @@ def lpp_voltage_from_bytes(buf):
     """
     logging.debug("lpp_voltage_from_bytes")
     val_i = __from_bytes(buf, 2)
-    if val_i >= (1 << 15):
-        logging.error("Negative Voltage value is not allowed")
-        raise AssertionError("Negative values are not allowed.")
+    
+    check_sign(val_i, 2)
     val = val_i / 100.0
+
     logging.debug("  out:   value = %f", val)
     return (val,)
 
@@ -116,7 +116,7 @@ def lpp_voltage_to_bytes(data):
     val = data[0]
     if val < 0:
         logging.error("Negative Voltage value is not allowed")
-        raise AssertionError("Negative values are not allowed")
+        raise ValueError("Negative values are not allowed")
     logging.debug("  in:    value = %f", val)
     val_i = int(val * 100)
     return __to_bytes(val_i, 2)
@@ -152,11 +152,17 @@ def lpp_analog_io_to_bytes(data):
 
 def lpp_generic_from_bytes(buf):
     """
-    Convert a 4 byte unsigned integer from bytes.
+    Decode generic from CyaenneLPP byte buffer,
+    and return the value as a tuple.
     """
     logging.debug("lpp_generic_from_bytes")
-    val_i = __from_bytes(buf, 4)
-    return (val_i,)
+    val = __from_bytes(buf, 4)
+
+    # Should generic max not be 2147483648 ? 
+    # check_sign(val, 4)  
+    
+    logging.debug("  out:   value = %f", val)
+    return (val,)
 
 
 def lpp_generic_to_bytes(data):
@@ -179,10 +185,11 @@ def lpp_unix_time_from_bytes(buf):
     Convert a 4 byte unix timestamp (unsigned integer) from bytes.
     """
     logging.debug("lpp_unix_time_from_bytes")
-    val_i = __from_bytes(buf, 4)
-    if val_i >= (1 << 31):
-        raise ValueError("Unix timestamp can not be negative.")
-    return (val_i,)
+    val = __from_bytes(buf, 4)
+    
+    check_sign(val, 4)
+    
+    return (val,)
 
 
 def lpp_unix_time_to_bytes(data):
@@ -200,11 +207,15 @@ def lpp_unix_time_to_bytes(data):
 
 def lpp_illuminance_from_bytes(buf):
     """
-    Decode illuminance sensor data from CyaenneLPP byte buffer,
-    and return the value as a tupel.
+    Decode illuminance from CyaenneLPP byte buffer,
+    and return the value as a tuple.
     """
     logging.debug("lpp_illuminance_from_bytes")
-    val = int(__from_bytes(buf, 2))
+    val = __from_bytes(buf, 2)
+    
+    check_sign(val, 2)
+    
+    logging.debug("  out:   value = %f", val)
     return (val,)
 
 
@@ -228,6 +239,9 @@ def lpp_presence_from_bytes(buf):
     """
     logging.debug("lpp_presence_from_bytes")
     val = __from_bytes(buf, 1)
+    
+    check_sign(val, 1)
+
     return (val,)
 
 
@@ -274,14 +288,18 @@ def lpp_temperature_to_bytes(data):
 
 def lpp_humidity_from_bytes(buf):
     """
-    Decode himidity sensor data from CyaenneLPP byte buffer,
-    and return the value as a tupel.
+    Decode humidity from CyaenneLPP byte buffer,
+    and return the value as a tuple.
     """
     logging.debug("lpp_humidity_from_bytes")
     val_i = __from_bytes(buf, 1)
-    val = val_i / 2.0
+    
+    check_sign(val_i, 1)
+    val = val_i / 2
+
     logging.debug("  out:   value = %f", val)
-    return (val, )
+    return (val,)
+
 
 
 def lpp_humidity_to_bytes(data):
@@ -352,12 +370,15 @@ def lpp_accel_to_bytes(data):
 
 def lpp_baro_from_bytes(buf):
     """
-    Decode barometer sensor data from CyaenneLPP byte buffer,
-    and return the value as a tupel.
+    Decode barometer from CyaenneLPP byte buffer,
+    and return the value as a tuple.
     """
     logging.debug("lpp_baro_from_bytes")
-    val = __from_bytes(buf, 2)
-    val = val / 10.0
+    val_i = __from_bytes(buf, 2)    
+
+    check_sign(val_i, 2)
+    val = val_i / 10
+
     logging.debug("  out:   value = %f", val)
     return (val,)
 
@@ -514,6 +535,86 @@ def lpp_load_to_bytes(data):
     logging.debug("  in:    value = %d", val_i)
     return __to_bytes(val_i, 3)
 
+def lpp_direction_from_bytes(buf):
+    """
+    Decode direction from CyaenneLPP byte buffer,
+    and return the value as a tuple.
+    """
+    logging.debug("lpp_direction_from_bytes")
+    val = __from_bytes(buf, 2)
+
+    check_sign(val, 2)
+    
+    logging.debug("  out:   value = %f", val)
+    return (val,)
+
+
+def lpp_direction_to_bytes(data):
+    """
+    Encode direction sensor data into CayenneLPP,
+    and return as a byte buffer
+    """
+    logging.debug("lpp_direction_to_bytes")
+    data = __assert_data_tuple(data, 1)
+    val_i = int(data[0])
+    if val_i < 0:
+        raise ValueError("Direction sensor values must be positive!")
+    return __to_bytes(val_i, 2)
+
+def lpp_current_from_bytes(buf):
+    """
+    Decode current from CyaenneLPP byte buffer,
+    and return the value as a tuple.
+    """
+    logging.debug("lpp_current_from_bytes")
+    val_i = __from_bytes(buf, 2)
+    
+    check_sign(val_i, 2)
+    val = val_i / 1000.0
+
+    logging.debug("  out:   value = %f", val)
+    return (val,)
+
+def lpp_current_to_bytes(data):
+    """
+    Encode current into CayenneLPP,
+    and return as a byte buffer
+    """
+    logging.debug("lpp_current_to_bytes")
+    data = __assert_data_tuple(data, 1)
+    val = data[0]
+    if val < 0:
+        logging.error("Negative Current value is not allowed")
+        raise ValueError("Negative values are not allowed")
+    logging.debug("  in:    value = %f", val)
+    val_i = int(val * 1000)
+    return __to_bytes(val_i, 2)
+
+
+def lpp_power_from_bytes(buf):
+    """
+    Decode power from CyaenneLPP byte buffer,
+    and return the value as a tuple.
+    """
+    logging.debug("lpp_power_from_bytes")
+    val = __from_bytes(buf, 2)
+
+    check_sign(val, 2)
+    
+    logging.debug("  out:   value = %f", val)
+    return (val,)
+
+def lpp_power_to_bytes(data):
+    """
+    Encode power sensor data into CayenneLPP,
+    and return as a byte buffer
+    """
+    logging.debug("lpp_power_to_bytes")
+    data = __assert_data_tuple(data, 1)
+    val_i = int(data[0])
+    if val_i < 0:
+        raise ValueError("Power sensor values must be positive!")
+    return __to_bytes(val_i, 2)
 
 class LppType(object):
     """Cayenne LPP type representation
@@ -570,8 +671,14 @@ LPP_TYPES = [
             lpp_baro_from_bytes, lpp_baro_to_bytes),
     LppType(116, 'Voltage', 2, 1,
             lpp_voltage_from_bytes, lpp_voltage_to_bytes),
+    LppType(117, 'Current', 2, 1,
+            lpp_current_from_bytes, lpp_current_to_bytes),
     LppType(122, 'Load', 3, 1,
             lpp_load_from_bytes, lpp_load_to_bytes),
+    LppType(128, 'Power', 2, 1,
+            lpp_power_from_bytes, lpp_power_to_bytes),
+    LppType(132, 'Direction', 2, 1,
+            lpp_direction_from_bytes, lpp_direction_to_bytes),
     LppType(133, 'Unix Timestamp', 4, 1,
             lpp_unix_time_from_bytes, lpp_unix_time_to_bytes),
     LppType(134, 'Gyrometer', 6, 3,
@@ -592,3 +699,9 @@ def get_lpp_type(type_):
         return next(filter(lambda x: x.type == type_, LPP_TYPES))
     except StopIteration:
         return None
+
+
+def check_sign(val, bufflen):
+    shift = 8*bufflen - 1
+    if val >= (1 << shift):
+        raise ValueError("Negative values are not allowed.")

--- a/cayennelpp/tests/test_lpp_type.py
+++ b/cayennelpp/tests/test_lpp_type.py
@@ -31,376 +31,158 @@ from cayennelpp.lpp_type import (lpp_digital_io_to_bytes,
                                  lpp_generic_from_bytes,
                                  lpp_unix_time_to_bytes,
                                  lpp_unix_time_from_bytes,
+                                 lpp_current_from_bytes,
+                                 lpp_current_to_bytes,
+                                 lpp_power_from_bytes,
+                                 lpp_power_to_bytes,
+                                 lpp_direction_from_bytes,
+                                 lpp_direction_to_bytes,
                                  get_lpp_type,
                                  LppType)
 
 
-def test_digital_io():
-    val = (0,)
-    dio_buf = lpp_digital_io_to_bytes(val)
-    assert lpp_digital_io_from_bytes(dio_buf) == val
-    val = (1,)
-    dio_buf = lpp_digital_io_to_bytes(val)
-    assert lpp_digital_io_from_bytes(dio_buf) == val
-
-
-def test_digital_io_invalid_buf():
-    with pytest.raises(Exception):
-        lpp_digital_io_from_bytes(bytearray([0x00, 0x00]))
-
-
-def test_digital_io_invalid_val_type():
-    with pytest.raises(Exception):
-        lpp_digital_io_to_bytes([0, 1])
-
-
-def test_digital_io_invalid_val():
-    with pytest.raises(Exception):
-        lpp_digital_io_to_bytes((0, 1))
-
-
-def test_analog_io():
-    val = (123.45,)
-    aio_buf = lpp_analog_io_to_bytes(val)
-    assert lpp_analog_io_from_bytes(aio_buf) == val
-    val = (-123.45,)
-    aio_buf = lpp_analog_io_to_bytes(val)
-    assert lpp_analog_io_from_bytes(aio_buf) == val
-
-
-def test_analog_io_invalid_buf():
-    with pytest.raises(Exception):
-        lpp_analog_io_from_bytes(bytearray([0x00]))
-
-
-def test_analog_io_invalid_val_type():
-    with pytest.raises(Exception):
-        lpp_analog_io_to_bytes([0, 1])
-
-
-def test_analog_io_invalid_val():
-    with pytest.raises(Exception):
-        lpp_analog_io_to_bytes((0, 1))
-
-
-def test_illuminance():
-    val = (12345,)
-    illu_buf = lpp_illuminance_to_bytes(val)
-    assert lpp_illuminance_from_bytes(illu_buf) == val
-
-
-def test_illuminance_invalid_buf():
-    with pytest.raises(Exception):
-        lpp_illuminance_from_bytes(bytearray([0x00]))
-
-
-def test_illuminance_invalid_val_type():
-    with pytest.raises(Exception):
-        lpp_illuminance_to_bytes([0, 1])
-
-
-def test_illuminance_invalid_val():
-    with pytest.raises(Exception):
-        lpp_illuminance_to_bytes((0, 1))
-
-
-def test_illuminance_negative_val():
-    with pytest.raises(Exception):
-        lpp_illuminance_to_bytes((-1,))
-
-
-def test_voltage():
-    val = (2,)
-    vol_buf = lpp_voltage_to_bytes(val)
-    assert lpp_voltage_from_bytes(vol_buf) == val
-
-
-def test_voltage_invalid_buf():
-    with pytest.raises(Exception):
-        lpp_voltage_from_bytes(bytearray([0x00]))
-
-
-def test_voltage_invalid_val():
-    with pytest.raises(Exception):
-        lpp_voltage_to_bytes((0, 1))
-
-
-def test_voltage_negative_val():
-    with pytest.raises(Exception):
-        lpp_voltage_to_bytes((-1,))
-    with pytest.raises(Exception):
-        # -25.0V
-        lpp_voltage_from_bytes(bytearray([0xf6, 0x3c]))
-
-
-def test_load():
-    val = (-5.432,)
-    aio_buf = lpp_load_to_bytes(val)
-    assert lpp_load_from_bytes(aio_buf) == val
-    val = (160.987,)
-    aio_buf = lpp_load_to_bytes(val)
-    assert lpp_load_from_bytes(aio_buf) == val
-
-
-def test_load_invalid_buf():
-    with pytest.raises(Exception):
-        lpp_load_from_bytes(bytearray([0x00]))
-
-
-def test_load_invalid_val_type():
-    with pytest.raises(Exception):
-        lpp_load_to_bytes([0, 1])
-
-
-def test_load_invalid_val():
-    with pytest.raises(Exception):
-        lpp_load_to_bytes((0, 1))
-
-
-def test_generic():
-    val = 4294967295
-    vol_buf = lpp_generic_to_bytes((val,))
-    assert lpp_generic_from_bytes(vol_buf) == (val,)
-
-
-def test_generic_invalid_buf():
-    with pytest.raises(Exception):
-        lpp_generic_from_bytes(bytearray([0x00, 0x00, 0x00]))
-
-
-def test_generic_invalid_val():
-    with pytest.raises(Exception):
-        lpp_generic_to_bytes((0, 1))
+@pytest.mark.parametrize(
+    "converter, test_value", [
+        (lpp_generic_to_bytes,      (-1,)),         # type 100
+        (lpp_illuminance_to_bytes,  (-1,)),         # type 101
+        (lpp_presence_to_bytes,     (-1,)),         # type 102
+        (lpp_humidity_to_bytes,     (-50.50,)),     # type 104
+        (lpp_baro_to_bytes,         (-1234.5,)),    # type 115    
+        (lpp_voltage_to_bytes,      (-1,)),         # type 116
+        (lpp_current_to_bytes,      (-1,)),         # type 117
+        (lpp_power_to_bytes,        (-1,)),         # type 128
+        (lpp_direction_to_bytes,    (-1,)),         # type 132
+        (lpp_unix_time_to_bytes,    (-1,)),         # type 133
+    ]
+)
+def test_should_raise_Exception_on_negative_to_bytes(converter, test_value):
+    # Test unsigned data type conversion to bytes  
     with pytest.raises(ValueError):
-        # val exceeds 4 bytes
-        val = 4294967297
-        lpp_generic_to_bytes((val,))
+        converter(test_value)
 
 
-def test_generic_negative_val():
-    with pytest.raises(Exception):
-        lpp_generic_to_bytes((-1,))
-
-
-def test_unix_time_datetime():
-    now = datetime.now(timezone.utc).timestamp()
-    vol_buf = lpp_unix_time_to_bytes((now,))
-    assert lpp_unix_time_from_bytes(vol_buf) == (int(now),)
-
-
-def test_unix_time_int():
-    val = 5
-    vol_buf = lpp_unix_time_to_bytes((val,))
-    assert lpp_unix_time_from_bytes(vol_buf) == (val,)
-
-
-def test_unix_time_invalid_buf():
-    with pytest.raises(Exception):
-        lpp_unix_time_from_bytes(bytearray([0x00]))
-
-
-def test_unix_time_invalid_val():
-    with pytest.raises(Exception):
-        lpp_unix_time_to_bytes((0, 1))
-    val = -5
+@pytest.mark.parametrize(
+    "converter, test_value", [
+    # (lpp_generic_from_bytes,    (0xff, 0xff, 0xcf, 0xc7,)) # val -12345    type 100
+    (lpp_illuminance_from_bytes,(0xff, 0xce,)),            # val -50       type 101
+    (lpp_presence_from_bytes,   (0xff,)),                  # val -1        type 102
+    (lpp_humidity_from_bytes,   (0x9b,)),                  # val -101      type 104
+    (lpp_baro_from_bytes,       (0xcf, 0xc,)),             # val -12345    type 115
+    (lpp_voltage_from_bytes,    (0xff, 0x9c,)),            # val -100      type 116
+    (lpp_current_from_bytes,    (0xff, 0xff,)),            # val -1        type 117
+    (lpp_power_from_bytes,      (0xff, 0xff,)),            # val -1        type 128
+    (lpp_direction_from_bytes,  (0xfe, 0x93,)),            # val -365      type 132
+    (lpp_unix_time_from_bytes,  (0xf8, 0x7b, 0x32, 0x0,)), # val -126144000  type 133
+    ]
+)
+def test_should_raise_ValueError_on_negative_from_bytes(converter, test_value):
+    # Test unsigned data type conversion from bytes
     with pytest.raises(ValueError):
-        # negative value
-        lpp_unix_time_to_bytes((val,))
+        converter(test_value)
 
 
-def test_unix_time_negative_val():
+@pytest.mark.parametrize(
+    "converter, test_value", [
+    (lpp_digital_io_to_bytes,   (0, 1)),    # type 0 / 1
+    (lpp_analog_io_to_bytes,    (0, 1)),    # type 2 / 3 
+    (lpp_generic_to_bytes,      (0, 1)),    # type 100
+    (lpp_illuminance_to_bytes,  (0, 1)),    # type 101
+    (lpp_presence_to_bytes,     (0, 1)),    # type 102
+    (lpp_temperature_to_bytes,  (0, 1)),    # type 103
+    (lpp_humidity_to_bytes,     (0, 1)),    # type 104
+    (lpp_accel_to_bytes,        (0, 1)),    # type 113
+    (lpp_baro_to_bytes,         (0, 1)),    # type 115
+    (lpp_voltage_to_bytes,      (0, 1)),    # type 116
+    (lpp_current_to_bytes,      (0, 1)),    # type 117
+    (lpp_load_to_bytes,         (0, 1)),    # type 122
+    (lpp_power_to_bytes,        (0, 1)),    # type 128
+    (lpp_direction_to_bytes,    (0, 1)),    # type 132
+    (lpp_unix_time_to_bytes,    (0, 1)),    # type 133
+    (lpp_gyro_to_bytes,         (0, 1)),    # type 134
+    (lpp_gps_to_bytes,          (0, 1)),    # type 136
+    ]
+)
+def test_should_raise_AssertionError_on_invalid_val(converter, test_value):
+    with pytest.raises(AssertionError):
+        converter(test_value)
+
+@pytest.mark.parametrize(
+    "converter, test_value", [
+    (lpp_digital_io_from_bytes,  [0x00, 0x00]),         # type 0 / 1
+    (lpp_analog_io_from_bytes,   [0x00]),               # type 0 / 1
+    (lpp_generic_from_bytes,     [0x00, 0x00, 0x00]),   # type 100
+    (lpp_illuminance_from_bytes, [0x00]),               # type 101
+    (lpp_presence_from_bytes,    [0x00, 0x00]),         # type 102
+    (lpp_temperature_from_bytes, [0x00]),               # type 103
+    (lpp_humidity_from_bytes,    [0x00, 0x00]),         # type 104
+    (lpp_accel_from_bytes,       [0x00]),               # type 113
+    (lpp_baro_from_bytes,        [0x00]),               # type 115
+    (lpp_voltage_from_bytes,     [0x00]),               # type 116
+    (lpp_current_from_bytes,     [0x00]),               # type 117
+    (lpp_load_from_bytes,        [0x00]),               # type 122
+    (lpp_power_from_bytes,       [0x00]),               # type 128
+    (lpp_direction_from_bytes,   [0x00]),               # type 132
+    (lpp_unix_time_from_bytes,   [0x00]),               # type 133
+    (lpp_gyro_from_bytes,        [0x00]),               # type 134
+    (lpp_gps_from_bytes,         [0x00]),               # type 136
+    ]
+)
+def test_should_raise_AssertionError_on_invalid_buf(converter, test_value):
+    with pytest.raises(AssertionError):
+        converter(bytearray(test_value))
+
+
+@pytest.mark.parametrize(
+    "converter, test_value", [
+    (lpp_digital_io_to_bytes,     [0x00, 0x00]),       # type 0 / 1
+    (lpp_analog_io_to_bytes,      [0x00]),             # type 1 / 2
+    (lpp_generic_to_bytes,        [0x00, 0x00, 0x00]), # type 100
+    (lpp_illuminance_to_bytes,    [0x00]),             # type 101
+    (lpp_presence_to_bytes,       [0x00, 0x00]),       # type 102
+    (lpp_temperature_to_bytes,    [0x00]),             # type 103
+    (lpp_humidity_to_bytes,       [0x00, 0x00]),       # type 104
+    (lpp_accel_to_bytes,          [0x00]),             # type 113
+    (lpp_baro_to_bytes,           [0x00]),             # type 115
+    (lpp_voltage_to_bytes,        [0x00]),             # type 116
+    (lpp_current_to_bytes,        [0x00]),             # type 117
+    (lpp_load_to_bytes,           [0x00]),             # type 122
+    (lpp_power_to_bytes,          [0x00]),             # type 128
+    (lpp_direction_to_bytes,      [0x00]),             # type 132
+    (lpp_unix_time_to_bytes,      [0x00]),             # type 133
+    (lpp_gyro_to_bytes,           [0x00]),             # type 134
+    (lpp_gps_to_bytes,            [0x00]),             # type 136
+    ]
+)
+def test_should_raise_Exception_on_invalid_val_type(converter, test_value):    
     with pytest.raises(Exception):
-        lpp_unix_time_to_bytes((-1,))
-    with pytest.raises(Exception):
-        # -4 years (-4*365*24*3600 seconds)
-        buff = bytearray([0xf8, 0x7b, 0x32, 0x0])
-        lpp_unix_time_from_bytes(buff)
+        converter(test_value)
 
-
-def test_presence():
-    val = (0,)
-    pre_buf = lpp_presence_to_bytes(val)
-    assert lpp_presence_from_bytes(pre_buf) == val
-    val = (1,)
-    pre_buf = lpp_presence_to_bytes(val)
-    assert lpp_presence_from_bytes(pre_buf) == val
-
-
-def test_presence_invalid_buf():
-    with pytest.raises(Exception):
-        lpp_presence_from_bytes(bytearray([0x00, 0x00]))
-
-
-def test_presence_invalid_val_type():
-    with pytest.raises(Exception):
-        lpp_presence_to_bytes([0, 1])
-
-
-def test_presence_invalid_val():
-    with pytest.raises(Exception):
-        lpp_presence_to_bytes((0, 1))
-
-
-def test_presence_negative_val():
-    with pytest.raises(Exception):
-        lpp_presence_to_bytes((-1,))
-
-
-def test_temperature():
-    val = (32.1,)
-    temp_buf = lpp_temperature_to_bytes(val)
-    assert lpp_temperature_from_bytes(temp_buf) == val
-    val = (-4.1,)
-    temp_buf = lpp_temperature_to_bytes(val)
-    assert lpp_temperature_from_bytes(temp_buf) == val
-
-
-def test_temperature_invalid_buf():
-    with pytest.raises(Exception):
-        lpp_temperature_from_bytes(bytearray([0x00]))
-
-
-def test_temperature_invalid_val_type():
-    with pytest.raises(Exception):
-        lpp_temperature_to_bytes([0x00])
-
-
-def test_temperature_invalid_val():
-    with pytest.raises(Exception):
-        lpp_temperature_to_bytes((0, 0))
-
-
-def test_humidity():
-    val = (50.00,)
-    hum_buf = lpp_humidity_to_bytes(val)
-    assert lpp_humidity_from_bytes(hum_buf) == val
-    hum_buf = lpp_humidity_to_bytes(50.25)
-    assert lpp_humidity_from_bytes(hum_buf) == val
-    val = (50.50,)
-    hum_buf = lpp_humidity_to_bytes(val)
-    assert lpp_humidity_from_bytes(hum_buf) == val
-    hum_buf = lpp_humidity_to_bytes(50.75)
-    assert lpp_humidity_from_bytes(hum_buf) == val
-
-
-def test_humidity_negative_val():
-    with pytest.raises(Exception):
-        val = (-50.50,)
-        lpp_humidity_to_bytes(val)
-
-
-def test_humidity_invalid_buf():
-    with pytest.raises(Exception):
-        lpp_humidity_from_bytes(bytearray([0x00, 0x00]))
-
-
-def test_humidity_invalid_val_type():
-    with pytest.raises(Exception):
-        lpp_humidity_to_bytes([0x00])
-
-
-def test_humidity_invalid_val():
-    with pytest.raises(Exception):
-        lpp_humidity_to_bytes((0, 0))
-
-
-def test_accelerometer():
-    val = (12.345, -12.345, 0.0)
-    accel_buf = lpp_accel_to_bytes(val)
-    assert lpp_accel_from_bytes(accel_buf) == val
-    val = (-12.345, 0.0, -12.345)
-    accel_buf = lpp_accel_to_bytes(val)
-    assert lpp_accel_from_bytes(accel_buf) == val
-
-
-def test_accelerometer_invalid_buf():
-    with pytest.raises(Exception):
-        lpp_accel_from_bytes(bytearray([0x00]))
-
-
-def test_accelerometer_invalid_val_type():
-    with pytest.raises(Exception):
-        lpp_accel_to_bytes([0x00])
-
-
-def test_accelerometer_invalid_val():
-    with pytest.raises(Exception):
-        lpp_accel_to_bytes((0, 0))
-
-
-def test_barometer():
-    val = (1234.5,)
-    baro_buf = lpp_baro_to_bytes(val)
-    assert lpp_baro_from_bytes(baro_buf) == val
-
-
-def test_barometer_negative_val():
-    with pytest.raises(Exception):
-        val = (-1234.5,)
-        lpp_baro_to_bytes(val)
-
-
-def test_barometer_invalid_buf():
-    with pytest.raises(Exception):
-        lpp_baro_from_bytes(bytearray([0x00]))
-
-
-def test_barometer_invalid_val_type():
-    with pytest.raises(Exception):
-        lpp_baro_to_bytes([0x00])
-
-
-def test_barometer_invalid_val():
-    with pytest.raises(Exception):
-        lpp_baro_to_bytes((0, 0))
-
-
-def test_gyrometer():
-    val = (123.45, -123.45, 0.0)
-    gyro_buf = lpp_gyro_to_bytes(val)
-    assert lpp_gyro_from_bytes(gyro_buf) == val
-    val = (-123.45, 0.0, -123.45)
-    gyro_buf = lpp_gyro_to_bytes(val)
-    assert lpp_gyro_from_bytes(gyro_buf) == val
-
-
-def test_gyrometer_invalid_buf():
-    with pytest.raises(Exception):
-        lpp_gyro_from_bytes(bytearray([0x00]))
-
-
-def test_gyrometer_invalid_val_type():
-    with pytest.raises(Exception):
-        lpp_gyro_to_bytes([0x00])
-
-
-def test_gyrometer_invalid_val():
-    with pytest.raises(Exception):
-        lpp_gyro_to_bytes((0, 0))
-
-
-def test_gps():
-    val = (42.3519, -87.9094, 10.00)
-    gps_buf = lpp_gps_to_bytes(val)
-    assert lpp_gps_from_bytes(gps_buf) == val
-    val = (-42.3519, 87.9094, -10.00)
-    gps_buf = lpp_gps_to_bytes(val)
-    assert lpp_gps_from_bytes(gps_buf) == val
-
-
-def test_gps_invalid_buf():
-    with pytest.raises(Exception):
-        lpp_gps_from_bytes(bytearray([0x00]))
-
-
-def test_gps_invalid_val_type():
-    with pytest.raises(Exception):
-        lpp_gps_to_bytes([0x00])
-
-
-def test_gps_invalid_val():
-    with pytest.raises(Exception):
-        lpp_gps_to_bytes((0, 0))
+@pytest.mark.parametrize(
+    "converter, test_cases", [
+    ("lpp_analog_io",   [(123.45,), (-123.45,)]),                                       # type 0 / 1
+    ("lpp_digital_io",  [(0,), (1,)]),                                                  # type 1 / 2
+    ("lpp_generic",     [(4294967295,)]),                                               # type 100
+    ("lpp_illuminance", [(12345,)]),                                                    # type 101
+    ("lpp_presence",    [(0,), (1,)]),                                                  # type 102    
+    ("lpp_temperature", [(32.1,), (-4.1,)]),                                            # type 103
+    ("lpp_humidity",    [(50.00,), (50.50,),]),                                         # type 104
+    ("lpp_accel",       [(12.345, -12.345, 0.0), (-12.345, 0.0, -12.345)]),             # type 113
+    ("lpp_baro",        [(1234.5,)]),                                                   # type 115
+    ("lpp_voltage",     [(2,)]),                                                        # type 116
+    ("lpp_current",     [(2,), (1,), (10,)]),                                           # type 117
+    ("lpp_load",        [(-5.432,), (160.987,)]),                                       # type 122
+    ("lpp_power",       [(1,), (10,), (15,)]),                                          # type 128
+    ("lpp_direction",   [(10,), (90,), (270,)]),                                        # type 132
+    ("lpp_unix_time",   [(int(datetime.now(timezone.utc).timestamp()),), (5,)]),        # type 133
+    ("lpp_gyro",        [(123.45, -123.45, 0.0), (-123.45, 0.0, -123.45)]),             # type 134
+    ("lpp_gps",         [(42.3519, -87.9094, 10.00), (-42.3519, 87.9094, -10.00)]),     # type 136
+    ]
+)
+def test_type_endode_should_equal_decode(converter, test_cases):
+    print(test_cases)
+    for case_val in test_cases:
+        buf = eval(converter+"_to_bytes")(case_val)
+        assert eval(converter+"_from_bytes")(buf) == case_val
 
 
 def test_init_invalid_type():


### PR DESCRIPTION
Hello everyone.

I started this fork with the intention to simply add three new lpp_types namely, `direction, current` and `power`.
I found the current testing procedure to be repetitive, and hence prone to missing specific tests.
To address this I parameterised, and extended the existing tests to streamline the addition and testing of new types.

Furthermore, I found a few  validating inconsistencies in the conversion procedure for unsigned byte types. 
To address this I created a standalone sign checking method, and implemented it where relevant.

My only concern is that the PR is quite massive. And for that I appologise sincerely. 
Ideally I should have split the PRs into smaller, more manageable chunks.