### PR TITLE
refactor: remove dependency on base64

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,6 @@ pip3 install pycayennelpp
 
 ### MicroPython Prerequisites
 
-MicroPython does not include the libraries `base64` and `logging` per default.
-While the latter rather optional for embedded devices, the former is essential.
 Using MicroPythons `upip` module PyCayenneLPP can be installed as follows
 within MicroPython:
 
@@ -67,8 +65,6 @@ Or alternatively run with in a shell:
 ```Shell
 micropython -m upip install micropython-pycayennelpp
 ```
-
-This will also install `micropython-base64` as a dependency.
 
 ### Usage Examples
 

--- a/cayennelpp/lpp_frame.py
+++ b/cayennelpp/lpp_frame.py
@@ -1,6 +1,5 @@
 from .lpp_data import LppData
 
-import base64
 try:
     import logging
 except ImportError:
@@ -62,13 +61,6 @@ class LppFrame(object):
             data.append(lppdata)
             i = i + lppdata.bytes_size()
         return cls(data)
-
-    @classmethod
-    def from_base64(cls, strb64):
-        """Parse LppFrame from a given base64 encoded string"""
-        logging.debug("LppFrame.from_base64: base64=%s, length=%d",
-                      strb64, len(strb64))
-        return cls.from_bytes(base64.decodebytes(strb64.encode('ascii')))
 
     def __add_data_item(self, item):
         if not isinstance(item, LppData):

--- a/cayennelpp/tests/test_lpp_frame.py
+++ b/cayennelpp/tests/test_lpp_frame.py
@@ -1,4 +1,5 @@
 import pytest
+import base64
 from datetime import datetime
 from datetime import timezone
 
@@ -70,9 +71,9 @@ def test_frame_from_bytes():
     assert len(frame) == 2
 
 
-def test_frame_from_base64():
-    base64 = "AYgILMMBiIMAAAACAAY="
-    frame = LppFrame.from_base64(base64)
+def test_frame_from_bytes_base64():
+    base64_str = "AYgILMMBiIMAAAACAAY="
+    frame = LppFrame.from_bytes(base64.decodebytes(base64_str.encode('ascii')))
     assert len(frame) == 2
 
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def readme():
 
 setup(
     name='pycayennelpp',
-    version='1.5.0',
+    version='2.0.0',
     python_requires='>=3.4',
     description='Encoder and Decoder for CayenneLLP',
     long_description=readme(),

--- a/usetup.py
+++ b/usetup.py
@@ -9,7 +9,7 @@ def readme():
 
 setup(
     name='micropython-pycayennelpp',
-    version='1.5.0',
+    version='2.0.0',
     description='Encoder and Decoder for CayenneLLP',
     long_description=readme(),
     long_description_content_type='text/markdown',
@@ -26,6 +26,5 @@ setup(
     license='MIT',
     packages=['cayennelpp'],
     cmdclass={'sdist': sdist_upip.sdist},
-    install_requires=['micropython-base64'],
     include_package_data=True
 )


### PR DESCRIPTION
fixes #63

by removing the dependency on base64 module, which is no standard module in micropython or other embedded python variants. Also it is not necessary to have this dependency in general and rather rely on the user doing such handling as necessary before passing data to pycayennelpp.

However, this breaks backwards compatibility in will therefore be included in the next major release. 