### PR TITLE
chore: update minimal Python version to 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
 python:
-  - "3.4"
-  - "3.5"
   - "3.6"
   - "3.7"
+  - "3.8"
+  - "3.9"
 # command to install dependencies
 install:
   - pip install flake8 pytest coverage "pytest-cov<2.6.0" codacy-coverage

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 Sebastian Meiling
+Copyright (c) 2018-2021 Sebastian Meiling
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ fly as soon as a certain number of new features and fixes have been made.
 ## Getting Started
 
 PyCayenneLPP does not have any external dependencies, but only uses builtin
-functions and types of Python 3. At least Python in version 3.4 is required.
+functions and types of Python 3. At least Python in version 3.6 is required,
+though Python 3.4 will do, 3.6 is the minimal officially supported version.
+
 Since version 1.2.0 MicroPython is supported, and published as a separate
 package under `micropython-pycayennelpp`.
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def readme():
 setup(
     name='pycayennelpp',
     version='2.0.0',
-    python_requires='>=3.4',
+    python_requires='>=3.6',
     description='Encoder and Decoder for CayenneLLP',
     long_description=readme(),
     long_description_content_type='text/markdown',
@@ -19,10 +19,10 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7'
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9'
     ],
     keywords='cayenne lpp iot lora lorawan ttn',
     url='http://github.com/smlng/pycayennelpp',


### PR DESCRIPTION
originally pycayennelpp started with Python 3.4 support, however the minimal officially supported version is now 3.6 as of 2021.

This adapts Travis config to test Python 3.6 up to 3.9.