### PR TITLE
chore: adapt .codacy.yml

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,3 +1,10 @@
+---
 exclude_paths:
   - '**/tests/**'
-  - 'CODE_OF_CONDUCT.md'
+  - '*.md'
+  - 'LICENSE'
+  - 'MANIFEST.in'
+  - 'setup.cfg'
+  - 'setup.py'
+  - 'usetup.py'
+  - 'sdist_upip.py'


### PR DESCRIPTION
add more files to be ignored by codacy anaylsis, all of them are support files.