### PR TITLE
Refactor: change bytes() method for LppData and LppFrame

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ frame = LppFrame()
 frame.add_temperature(0, -1.2)
 frame.add_humidity(6, 34.5)
 # get byte buffer in CayenneLPP format
-buffer = frame.bytes()
+buffer = bytes(frame)
 ```
 
 ***Decoding***

--- a/cayennelpp/lpp_data.py
+++ b/cayennelpp/lpp_data.py
@@ -26,6 +26,13 @@ class LppData(object):
         self.value = value
         self._size = self.type.size + 2
 
+    def __bytes__(self):
+        """Return a byte string representation of this LppData object."""
+        hdr_buf = bytearray([self.channel, int(self.type)])
+        dat_buf = self.type.encode(self.value)
+        buf = hdr_buf + dat_buf
+        return bytes(buf)
+
     def __str__(self):
         """Return a pretty string representation of the LppData object."""
         return 'LppData(channel = {}, type = {}, value = {})'.format(
@@ -44,13 +51,6 @@ class LppData(object):
             raise BufferError("Buffer too small!")
         value = lpp_type.decode(buf[2:(2 + size)])
         return class_object(chn, type_, value)
-
-    def bytes(self):
-        """Return a byte string representation of this LppData object."""
-        hdr_buf = bytearray([self.channel, int(self.type)])
-        dat_buf = self.type.encode(self.value)
-        buf = hdr_buf + dat_buf
-        return buf
 
     @property
     def size(self):

--- a/cayennelpp/lpp_data.py
+++ b/cayennelpp/lpp_data.py
@@ -32,6 +32,10 @@ class LppData(object):
         buf = hdr_buf + dat_buf
         return bytes(buf)
 
+    def __len__(self):
+        """Return the length of the LppData byte string representation."""
+        return self.type.size + 2
+
     def __str__(self):
         """Return a pretty string representation of the LppData object."""
         return 'LppData(channel = {}, type = {}, value = {})'.format(
@@ -50,8 +54,3 @@ class LppData(object):
             raise BufferError("Buffer too small!")
         value = lpp_type.decode(buf[2:(2 + size)])
         return class_object(chn, type_, value)
-
-    @property
-    def size(self):
-        """Return the length of the LppData byte string representation."""
-        return self.type.size + 2

--- a/cayennelpp/lpp_data.py
+++ b/cayennelpp/lpp_data.py
@@ -24,7 +24,6 @@ class LppData(object):
         if not len(value) == self.type.dimension:
             raise ValueError("Invalid number of data values!")
         self.value = value
-        self._size = self.type.size + 2
 
     def __bytes__(self):
         """Return a byte string representation of this LppData object."""
@@ -55,4 +54,4 @@ class LppData(object):
     @property
     def size(self):
         """Return the length of the LppData byte string representation."""
-        return self._size
+        return self.type.size + 2

--- a/cayennelpp/lpp_frame.py
+++ b/cayennelpp/lpp_frame.py
@@ -62,7 +62,7 @@ class LppFrame(object):
         """Return this LppFrame object as a byte string."""
         buf = bytearray()
         for d in self._data:
-            buf = buf + d.bytes()
+            buf = buf + bytes(d)
         return buf
 
     @property

--- a/cayennelpp/lpp_frame.py
+++ b/cayennelpp/lpp_frame.py
@@ -53,7 +53,7 @@ class LppFrame(object):
         while i < len(buf):
             lppdata = LppData.from_bytes(buf[i:])
             data.append(lppdata)
-            i = i + lppdata.size
+            i = i + len(lppdata)
         return cls(data)
 
     def __add_data_item(self, item):
@@ -61,7 +61,7 @@ class LppFrame(object):
         if not isinstance(item, LppData):
             raise TypeError()
         if self.maxsize > 0:
-            if self.size + item.size > self.maxsize:
+            if self.size + len(item) > self.maxsize:
                 raise BufferError()
         self._data.append(item)
 
@@ -93,7 +93,7 @@ class LppFrame(object):
         """Return the length of the LppFrame byte string representation."""
         size = 0
         for d in self._data:
-            size += d.size
+            size += len(d)
         return size
 
     def get_by_type(self, type_):

--- a/cayennelpp/lpp_frame.py
+++ b/cayennelpp/lpp_frame.py
@@ -38,6 +38,13 @@ class LppFrame(object):
             yield self._data[count]
             count += 1
 
+    def __bytes__(self):
+        """Return this LppFrame object as a byte string."""
+        buf = bytearray()
+        for d in self._data:
+            buf = buf + bytes(d)
+        return bytes(buf)
+
     @classmethod
     def from_bytes(cls, buf):
         """Parse a given byte string and return as a LppFrame object."""
@@ -57,13 +64,6 @@ class LppFrame(object):
             if self.size + item.size > self.maxsize:
                 raise BufferError()
         self._data.append(item)
-
-    def bytes(self):
-        """Return this LppFrame object as a byte string."""
-        buf = bytearray()
-        for d in self._data:
-            buf = buf + bytes(d)
-        return buf
 
     @property
     def data(self):

--- a/cayennelpp/tests/test_lpp_data.py
+++ b/cayennelpp/tests/test_lpp_data.py
@@ -91,7 +91,7 @@ def test_gps_from_bytes_invalid_size():
 
 
 def test_lpp_data_size():
-    assert LppData(0, 0, 0).size == 3
+    assert len(LppData(0, 0, 0)) == 3
 
 
 def test_lpp_data_str():

--- a/cayennelpp/tests/test_lpp_data.py
+++ b/cayennelpp/tests/test_lpp_data.py
@@ -5,61 +5,61 @@ from cayennelpp.lpp_data import LppData
 
 def test_temperature_from_bytes():
     # 01 67 FF D7 = -4.1C
-    temp_buf = bytearray([0x01, 0x67, 0xFF, 0xD7])
+    temp_buf = bytes([0x01, 0x67, 0xFF, 0xD7])
     temp_dat = LppData.from_bytes(temp_buf)
-    assert temp_buf == temp_dat.bytes()
+    assert temp_buf == bytes(temp_dat)
 
 
 def test_accelerometer_from_bytes():
     # 06 71 04 D2 FB 2E 00 00
-    acc_buf = bytearray([0x06, 0x71, 0x04, 0xD2, 0xFB, 0x2E, 0x00, 0x00])
+    acc_buf = bytes([0x06, 0x71, 0x04, 0xD2, 0xFB, 0x2E, 0x00, 0x00])
     acc_dat = LppData.from_bytes(acc_buf)
-    assert acc_buf == acc_dat.bytes()
+    assert acc_buf == bytes(acc_dat)
 
 
 def test_generic_from_bytes():
-    buff = bytearray([0x00, 0x64, 0xff, 0xff, 0xff, 0xfb])
+    buff = bytes([0x00, 0x64, 0xff, 0xff, 0xff, 0xfb])
     data = LppData.from_bytes(buff)
-    assert buff == data.bytes()
+    assert buff == bytes(data)
     assert int(data.type) == 100
     assert data.value == (4294967291,)
 
 
 def test_generic_from_bytes_invalid_size():
     with pytest.raises(Exception):
-        buf = bytearray([0x00, 0x64, 0x00, 0x00, 0x00])
+        buf = bytes([0x00, 0x64, 0x00, 0x00, 0x00])
         LppData.from_bytes(buf)
 
 
 def test_gps_from_bytes():
     # 01 88 06 76 5f f2 96 0a 00 03 e8
-    gps_buf = bytearray([0x01, 0x88, 0x06, 0x76,
-                         0x5f, 0xf2, 0x96, 0x0a,
-                         0x00, 0x03, 0xe8])
+    gps_buf = bytes([0x01, 0x88, 0x06, 0x76,
+                    0x5f, 0xf2, 0x96, 0x0a,
+                    0x00, 0x03, 0xe8])
     gps_dat = LppData.from_bytes(gps_buf)
-    assert gps_buf == gps_dat.bytes()
+    assert gps_buf == bytes(gps_dat)
 
 
 def test_voltage_from_bytes():
     # 25V on channel 1
-    buff = bytearray([0x01, 0x74, 0x9, 0xc4])
+    buff = bytes([0x01, 0x74, 0x9, 0xc4])
     data = LppData.from_bytes(buff)
-    assert buff == data.bytes()
+    assert buff == bytes(data)
     assert data.value == (25,)
 
 
 def test_load_from_bytes():
     # 42.321kg on channel 0
-    buff = bytearray([0x00, 0x7A, 0x00, 0xA5, 0x51])
+    buff = bytes([0x00, 0x7A, 0x00, 0xA5, 0x51])
     data = LppData.from_bytes(buff)
-    assert buff == data.bytes()
+    assert buff == bytes(data)
 
 
 def test_unix_time_from_bytes():
     # 1970-01-01T08:00Z (ie unix time 0)
-    buff = bytearray([0x01, 0x85, 0x00, 0x00, 0x00, 0x00])
+    buff = bytes([0x01, 0x85, 0x00, 0x00, 0x00, 0x00])
     data = LppData.from_bytes(buff)
-    assert buff == data.bytes()
+    assert buff == bytes(data)
     assert data.value == (0,)
 
 
@@ -80,13 +80,13 @@ def test_init_invalid_dimension():
 
 def test_any_from_bytes_invalid_size():
     with pytest.raises(Exception):
-        buf = bytearray([0x00, 0x00])
+        buf = bytes([0x00, 0x00])
         LppData.from_bytes(buf)
 
 
 def test_gps_from_bytes_invalid_size():
     with pytest.raises(Exception):
-        buf = bytearray([0x00, 0x88, 0x00])
+        buf = bytes([0x00, 0x88, 0x00])
         LppData.from_bytes(buf)
 
 

--- a/cayennelpp/tests/test_lpp_frame.py
+++ b/cayennelpp/tests/test_lpp_frame.py
@@ -24,7 +24,7 @@ def frame_hlt():
 def test_empty_frame(frame):
     assert not frame.data
     assert len(frame) == 0
-    assert not frame.bytes()
+    assert not bytes(frame)
 
 
 def test_init_invalid_data_nolist():
@@ -79,9 +79,9 @@ def test_frame_maxsize_exceeded(frame):
 
 def test_frame_from_bytes():
     # 03 67 01 10 05 67 00 FF = 27.2C + 25.5C
-    buf = bytearray([0x03, 0x67, 0x01, 0x10, 0x05, 0x67, 0x00, 0xff])
+    buf = bytes([0x03, 0x67, 0x01, 0x10, 0x05, 0x67, 0x00, 0xff])
     frame = LppFrame.from_bytes(buf)
-    assert buf == frame.bytes()
+    assert buf == bytes(frame)
     assert len(frame) == 2
 
 
@@ -162,7 +162,6 @@ def test_add_unix_time(frame):
     assert len(frame) == 2
     assert int(frame.data[0].type) == 133
     assert int(frame.data[1].type) == 133
-    frame.bytes()
 
 
 def test_add_temperature(frame):


### PR DESCRIPTION
several changes to ease handling of LppData and LppFrame, i.e. use `bytes(LppFrame)` instead of `LppFrame.bytes()`, same for LppData. Also use `len(LppData)` instead of `LppData.size`. 