### PR TITLE
feat: add lpp_util with json encoder 

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,35 @@ frame = LppFrame().from_bytes(buffer)
 print(frame)
 ```
 
+***JSON Encoding***
+
+The LppUtil class provides helper function for proper JSON encoding of 
+PyCayenneLpp types, i.e. LppFrame, LppData and LppType.
+
+```python
+import json
+
+from cayennelpp import LppFrame, LppUtil
+
+# create empty frame
+frame = LppFrame()
+# add some sensor data
+frame.add_temperature(0, -1.2)
+frame.add_humidity(6, 34.5)
+# json encoding
+print(json.dumps(frame, default=LppUtil.json_encode, indent=2))
+```
+
+There are two wrapper functions to explicitly encode the LPP type as a 
+number or string, number being default for `LppUtil.json_encode` (see above):
+
+```python
+# type as number
+print(json.dumps(frame, default=LppUtil.json_encode_type_int, indent=2))
+# type as string
+print(json.dumps(frame, default=LppUtil.json_encode_type_str, indent=2))
+```
+
 ## Contributing
 
 Contributing to a free open source software project can take place in many

--- a/cayennelpp/__init__.py
+++ b/cayennelpp/__init__.py
@@ -6,5 +6,6 @@ functionality for the CayenneLPP format, supporting many sensor types.
 
 from .lpp_data import LppData
 from .lpp_frame import LppFrame
+from .lpp_util import LppUtil
 
-__all__ = ['LppData', 'LppFrame']
+__all__ = ['LppData', 'LppFrame', 'LppUtil']

--- a/cayennelpp/lpp_data.py
+++ b/cayennelpp/lpp_data.py
@@ -15,7 +15,7 @@ class LppData(object):
     """
 
     def __init__(self, chn, type_, value):
-        """Create a LppData object with given attriubes."""
+        """Create a LppData object with given attributes."""
         self.channel = chn
         self.type = LppType.get_lpp_type(type_)
         if self.type is None:

--- a/cayennelpp/lpp_util.py
+++ b/cayennelpp/lpp_util.py
@@ -1,0 +1,34 @@
+from .lpp_data import LppData
+from .lpp_frame import LppFrame
+from .lpp_type import LppType
+
+
+class LppUtil():
+    """Cayenne LPP utility functions.
+
+    This class provides helper functions and wrapper, e.g. for encoding and
+    decoding LppType, LppData, and LppFrame into various data formats.
+    """
+
+    @staticmethod
+    def json_encode(obj, type2str=False):
+        """Encode LppType, LppData, and LppFrame to JSON."""
+        if isinstance(obj, LppType):
+            if type2str:
+                return obj.name
+            return obj.type
+        if isinstance(obj, LppData):
+            return obj.__dict__
+        if isinstance(obj, LppFrame):
+            return obj.data
+        raise TypeError(repr(obj) + " is not JSON serialized")
+
+    @classmethod
+    def json_encode_type_int(cls, obj):
+        """Wrapper function encode type as int in JSON."""
+        return cls.json_encode(obj, False)
+
+    @classmethod
+    def json_encode_type_str(cls, obj):
+        """Wrapper function encode type as string in JSON."""
+        return cls.json_encode(obj, True)

--- a/cayennelpp/tests/test_lpp_util.py
+++ b/cayennelpp/tests/test_lpp_util.py
@@ -1,0 +1,34 @@
+import pytest
+import json
+
+from cayennelpp.lpp_frame import LppFrame
+from cayennelpp.lpp_util import LppUtil
+
+
+@pytest.fixture
+def frame():
+    lf = LppFrame()
+    lf.add_humidity(3, 45.6)
+    lf.add_temperature(2, 12.3)
+    return lf
+
+
+def test_json_encode_type_int(frame):
+    dump_int = json.dumps(frame, default=LppUtil.json_encode_type_int)
+    assert len(dump_int) > 0
+    load_int = json.loads(dump_int)
+    for o in load_int:
+        assert isinstance(o['type'], int)
+
+
+def test_json_encode_type_str(frame):
+    dump_str = json.dumps(frame, default=LppUtil.json_encode_type_str)
+    assert len(dump_str) > 0
+    load_str = json.loads(dump_str)
+    for o in load_str:
+        assert isinstance(o['type'], str)
+
+
+def test_json_encode_invalid():
+    with pytest.raises(TypeError):
+        json.dumps(type("foobar", (object,), {}), default=LppUtil.json_encode)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def readme():
 
 setup(
     name='pycayennelpp',
-    version='2.2.0',
+    version='2.3.0',
     python_requires='>=3.6',
     description='Encoder and Decoder for CayenneLLP',
     long_description=readme(),

--- a/usetup.py
+++ b/usetup.py
@@ -9,7 +9,7 @@ def readme():
 
 setup(
     name='micropython-pycayennelpp',
-    version='2.2.0',
+    version='2.3.0',
     description='Encoder and Decoder for CayenneLLP',
     long_description=readme(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Note this is work in progress.

This introduces a new file `lpp_util.py` which currently only contains a helper function to allow for proper json encoding of a LppFrame. Example would be like this:

```python
import json

from cayennelpp import LppFrame, LppUtil

# create empty frame
frame = LppFrame()
# add some sensor data
frame.add_temperature(0, -1.2)
frame.add_humidity(6, 34.5)
# json encoding
print(json.dumps(frame, default=LppUtil.json_encode, indent=2))
```

there are 2 wrapper functions to explicitly encode the LPP type as a number or string, number being the default when using `LppUtil.json_encode`:

```python
# type as number
print(json.dumps(frame, default=LppUtil.json_encode_type_int, indent=2))
# type as string
print(json.dumps(frame, default=LppUtil.json_encode_type_str, indent=2))
```
fixes #101 